### PR TITLE
Remove domain repository from aggregation

### DIFF
--- a/nightly.aggr
+++ b/nightly.aggr
@@ -5,7 +5,6 @@
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/change"/>
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/framework"/>
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/dsls"/>
-      <repositories location="https://vitruv-tools.github.io/updatesite/nightly/domains/cbs"/>
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/applications/cbs"/>
     </contributions>
     <contributions label="externals">


### PR DESCRIPTION
To be merged after the domains have been removed from all other projects, i.e., after vitruv-tools/Vitruv-Change#14, vitruv-tools/Vitruv#541, vitruv-tools/Vitruv-DSLs#30 and vitruv-tools/Vitruv-Applications-ComponentBasedSystems#204 have been merged.