### PR TITLE
Adapt to renamed case studies repository

### DIFF
--- a/nightly.aggr
+++ b/nightly.aggr
@@ -5,7 +5,7 @@
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/change"/>
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/framework"/>
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/dsls"/>
-      <repositories location="https://vitruv-tools.github.io/updatesite/nightly/applications/cbs"/>
+      <repositories location="https://vitruv-tools.github.io/updatesite/nightly/case-studies"/>
       <repositories location="https://vitruv-tools.github.io/updatesite/nightly/adapters"/>
     </contributions>
     <contributions label="externals">


### PR DESCRIPTION
Depends on https://github.com/vitruv-tools/Vitruv-CaseStudies/pull/231